### PR TITLE
Add VorbisFile to csproj

### DIFF
--- a/FNA.csproj
+++ b/FNA.csproj
@@ -107,6 +107,7 @@
     <Compile Include="src\Audio\SoundEffect.cs" />
     <Compile Include="src\Audio\SoundEffectInstance.cs" />
     <Compile Include="src\Audio\SoundState.cs" />
+    <Compile Include="src\Audio\Vorbisfile.cs" />
     <Compile Include="src\Audio\WaveBank.cs" />
     <Compile Include="src\BoundingBox.cs" />
     <Compile Include="src\BoundingFrustum.cs" />

--- a/app.config
+++ b/app.config
@@ -11,4 +11,8 @@
 	<dllmap dll="FAudio" os="windows" target="FAudio.dll"/>
 	<dllmap dll="FAudio" os="osx" target="libFAudio.0.dylib"/>
 	<dllmap dll="FAudio" os="linux,freebsd,netbsd" target="libFAudio.so.0"/>
+
+	<dllmap os="windows" dll="libvorbisfile" target="libvorbisfile.dll"/>
+	<dllmap os="osx" dll="libvorbisfile" target="libvorbisfile.3.dylib"/>
+	<dllmap os="linux" dll="libvorbisfile" target="libvorbisfile.so.3"/>
 </configuration>


### PR DESCRIPTION
Include Vorbisfile.cs in the csproj so it is included in builds done by Visual Studio etc.